### PR TITLE
Fix: incorrect math_example.py path in README (fix 404 error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install langchain langchain-anthropic
 
 ## Example
 
-A full version of this in one file can be found [here](examples/math.py)
+A full version of this in one file can be found [here](examples/math_example.py)
 
 ### 1. Define your tools
 


### PR DESCRIPTION
The previous README file referenced `examples/math.py`, which resulted in a 404 error.   Updated the path to the correct `examples/math_example.py` .